### PR TITLE
Configure Dependabot Labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: [chore]
 
   - package-ecosystem: pip
     directory: /
@@ -13,3 +14,4 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: [chore]


### PR DESCRIPTION
This pull request configures the labels used by Dependabot to be `chore`.