### PR TITLE
Implement isort for Import Sorting

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Check format
         run: |
+          poetry run isort lib
           poetry run black lib
           git diff --exit-code HEAD
 

--- a/lib/starter/__main__.py
+++ b/lib/starter/__main__.py
@@ -1,4 +1,5 @@
 import sys
+
 from . import fibonacci_series
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,6 +71,23 @@ files = [
 ]
 
 [[package]]
+name = "isort"
+version = "5.12.0"
+description = "A Python utility / library to sort Python imports."
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
+]
+
+[package.extras]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -132,4 +149,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "8ba347df668fbc1bae8b4278ac2c5ffcf36981629d7e6a51655ed7a960b7151c"
+content-hash = "913fb0772a165cf63552a38fb8d800444f1c5e483cd00d586eb8727a81f88f76"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"
+isort = "^5.12.0"
 
 [tool.poetry.scripts]
 starter = "starter.__main__:main"


### PR DESCRIPTION
This pull request introduces [isort](https://pycqa.github.io/isort/) to organize imports within the Python source code of this template repository. It resolves #5.