### PR TITLE
Cache Poetry Installation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
           echo "local_venvs=$(pipx environment -v PIPX_LOCAL_VENVS)" >> $GITHUB_OUTPUT
 
       - name: Cache Poetry
+        id: cache_poetry
         uses: actions/cache@v3.3.1
         with:
           path: |
@@ -36,6 +37,7 @@ jobs:
           key: poetry-${{ runner.os }}-${{ hashFiles('.github/workflows/build.yaml') }}
 
       - name: Setup Poetry
+        if: steps.cache_poetry.outputs.cache-hit != 'true'
         run: pipx install poetry
 
       - name: Install deps

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,12 +20,19 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Get pipx variables
+        id: pipx_vars
+        shell: bash
+        run: |
+          echo "bin_dir=$(pipx environment -v PIPX_BIN_DIR)" >> $GITHUB_OUTPUT
+          echo "local_venvs=$(pipx environment -v PIPX_LOCAL_VENVS)" >> $GITHUB_OUTPUT
+
       - name: Cache Poetry
         uses: actions/cache@v3.3.1
         with:
           path: |
-            ~/.local/bin/poetry
-            ~/.local/pipx/venvs/poetry
+            ${{ steps.pipx_vars.outputs.bin_dir }}/poetry*
+            ${{ steps.pipx_vars.outputs.local_venvs }}/poetry
           key: poetry-${{ runner.os }}-${{ hashFiles('.github/workflows/build.yaml') }}
 
       - name: Setup Poetry

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
         id: pipx_vars
         shell: bash
         run: |
+          echo "version=$(pipx --version)" >> $GITHUB_OUTPUT
           echo "bin_dir=$(pipx environment -v PIPX_BIN_DIR)" >> $GITHUB_OUTPUT
           echo "local_venvs=$(pipx environment -v PIPX_LOCAL_VENVS)" >> $GITHUB_OUTPUT
 
@@ -34,7 +35,7 @@ jobs:
           path: |
             ${{ steps.pipx_vars.outputs.bin_dir }}/poetry*
             ${{ steps.pipx_vars.outputs.local_venvs }}/poetry
-          key: poetry-${{ runner.os }}-${{ hashFiles('.github/workflows/build.yaml') }}
+          key: pipx-${{ steps.pipx_vars.outputs.version }}-poetry-${{ runner.os }}
 
       - name: Setup Poetry
         if: steps.cache_poetry.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,14 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Cache Poetry
+        uses: actions/cache@v3.3.1
+        with:
+          path: |
+            ~/.local/bin/poetry
+            ~/.local/pipx/venvs/poetry
+          key: poetry-${{ runner.os }}-${{ hashFiles('.github/workflows/build.yaml') }}
+
       - name: Setup Poetry
         run: pipx install poetry
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           python-version: 3.11
 
       - name: Setup Poetry
-        uses: abatilo/actions-poetry@v2.3.0
+        run: pipx install poetry
 
       - name: Install deps
         run: poetry install --with dev


### PR DESCRIPTION
This pull request modifies the Poetry installation process in the `build.yaml` workflow as follows:
- Utilizes [pipx](https://pypa.github.io/pipx/) for installing Poetry, following the guidance outlined in [this recommendation](https://python-poetry.org/docs/#ci-recommendations).
- Implements caching for Poetry files installed in the pipx directories.

This resolves #12.