### PR TITLE
Rename Test Job to Build in CI Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  test:
-    name: Test
+  build:
+    name: Build
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This pull request simply renames the Test job in the CI workflow to Build job. It closes #47.