### PR TITLE
Deploy Documentation to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,3 +51,26 @@ jobs:
         uses: actions/upload-pages-artifact@v2.0.0
         with:
           path: docs
+
+  deploy:
+    name: Deploy
+    if: github.event_name != 'pull_request' && github.ref_name == 'main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v3.0.6
+
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v2.0.4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,3 +46,8 @@ jobs:
 
       - name: Generate docs
         run: poetry run poe docs
+
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v2.0.0
+        with:
+          path: docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [Windows, Ubuntu, macOS]
+        os: [windows, ubuntu, macos]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -48,6 +48,7 @@ jobs:
         run: poetry run poe docs
 
       - name: Upload docs artifact
+        if: ${{ matrix.os }} == 'ubuntu'
         uses: actions/upload-pages-artifact@v2.0.0
         with:
           path: docs

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The Python Starter is a [GitHub repository template](https://docs.github.com/en/
 - Import sorting with [isort](https://pycqa.github.io/isort/).
 - Static analysis and linting with [Flake8](https://flake8.pycqa.org/en/latest/).
 - Preconfigured [GitHub Actions](https://github.com/features/actions) workflow for CI.
+- Documentation deployment on [GitHub Pages](https://pages.github.com/).
 - [Dependabot](https://docs.github.com/en/code-security/dependabot) support for dependency updates.
 
 ## Usage


### PR DESCRIPTION
This pull request adds support for documentation deployment of this project API to [GitHub Pages](https://pages.github.com/) by adding a deployment job to the CI workflow. It closes #46.