### PR TITLE
Run Workflows on Ubuntu OS Only

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,11 +7,7 @@ on:
 jobs:
   build:
     name: Build Package
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
This pull request resolves #75 by running the `build-package` job of the `build.yaml` workflow only on Ubuntu OS.