### PR TITLE
Separate Workflows for Build and Test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  build:
-    name: Build Package
+  generate-docs:
+    name: Generate Documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,15 +30,6 @@ jobs:
       - name: Install Dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: poetry install --with dev
-
-      - name: Check Format
-        run: poetry run poe format && git diff --exit-code HEAD
-
-      - name: Check Lint
-        run: poetry run poe lint
-
-      - name: Test Package
-        run: poetry run poe test
 
       - name: Generate Documentation
         run: poetry run poe docs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,40 @@ on:
   push:
     branches: [main]
 jobs:
+  build-package:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Python
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: 3.11
+
+      - name: Setup Poetry
+        uses: threeal/setup-poetry-action@v1.0.0
+
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: actions/cache@v3.3.2
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+
+      - name: Install Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: poetry install --with dev
+
+      - name: Build Package
+        run: poetry build
+
+      - name: Upload Package
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          path: dist/*
+
   generate-docs:
     name: Generate Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,73 @@
+name: Test
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  check-package:
+    name: Check Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Python
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: 3.11
+
+      - name: Setup Poetry
+        uses: threeal/setup-poetry-action@v1.0.0
+
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: actions/cache@v3.3.2
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+
+      - name: Install Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: poetry install --with dev
+
+      - name: Check Format
+        run: |
+          poetry run poe format
+          git diff --exit-code HEAD
+
+      - name: Check Lint
+        run: poetry run poe lint
+
+  test-package:
+    name: Test Package
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows, ubuntu, macos]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Python
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: 3.11
+
+      - name: Setup Poetry
+        uses: threeal/setup-poetry-action@v1.0.0
+
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: actions/cache@v3.3.2
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+
+      - name: Install Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: poetry install --with dev
+
+      - name: Test Package
+        run: poetry run poe test

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 
 *.egg-info
 __pycache__
+dist
 docs

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![version](https://img.shields.io/github/v/release/threeal/python-starter?style=flat-square)](https://github.com/threeal/python-starter/releases)
 [![license](https://img.shields.io/github/license/threeal/python-starter?style=flat-square)](./LICENSE)
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/python-starter/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/python-starter/actions/workflows/build.yaml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/python-starter/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/python-starter/actions/workflows/test.yaml)
 [![deploy status](https://img.shields.io/github/actions/workflow/status/threeal/python-starter/deploy.yaml?branch=main&label=deploy&style=flat-square)](https://github.com/threeal/python-starter/actions/workflows/deploy.yaml)
 
 The Python Starter is a [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) that provides a minimalistic boilerplate to kickstart your [Python](https://www.python.org/) project. This template offers a streamlined foundation, complete with predefined file structures, essential tools, and recommended settings, ensuring a swift and efficient start to your Python development journey.


### PR DESCRIPTION
This pull request resolves #74 by separating workflows for building and testing into `build.yaml` and `test.yaml` workflows. It also adds a new `build-package` job for building the package into source and wheel archives.