### PR TITLE
Remove `check` Task From Poe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ ruff = "^0.1.9"
 my_fibonacci = "my_fibonacci.__main__:main"
 
 [tool.poe.tasks]
-check = ["format", "lint"]
 docs = "pydoctor --make-html --html-output=docs lib/my_fibonacci"
 format = "ruff format lib tests"
 lint = "ruff check lib tests"


### PR DESCRIPTION
This pull request simply removes `check` task from the `tool.poe.tasks` entry in the `pyproject.toml` file.