### PR TITLE
Run Test Workflow on Ubuntu OS Only

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,11 +41,7 @@ jobs:
 
   test-package:
     name: Test Package
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
This pull request modifies the `test-package` job of the `test.yaml` workflow to be run only on Ubuntu OS. This pull request should be part of #76.