### PR TITLE
Output Documentation to `apidocs` Directory

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Upload Documentation
         uses: actions/upload-pages-artifact@v3.0.0
         with:
-          path: docs
+          path: apidocs
 
       - name: Deploy Pages
         id: deploy-pages

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 
 *.egg-info
 __pycache__
+apidocs
 dist
-docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ ruff = "^0.1.9"
 my_fibonacci = "my_fibonacci.__main__:main"
 
 [tool.poe.tasks]
-docs = "pydoctor --make-html --html-output=docs lib/my_fibonacci"
+docs = "pydoctor --make-html lib/my_fibonacci"
 format = "ruff format lib tests"
 lint = "ruff check lib tests"
 test = "pytest -v --cov=my_fibonacci"


### PR DESCRIPTION
This pull request modifies the `docs` task to output the documentation to `apidocs` directory, following the default output directory used by pydoctor.