### PR TITLE
Expand Enabled Rules in Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I"]
+extend-select = ["E", "W", "C90", "I", "N"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N"]
+extend-select = ["E", "W", "C90", "I", "N", "UP"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["I"]
+extend-select = ["E", "W", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "I"]
+extend-select = ["E", "W", "C90", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN"]
+extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP"]


### PR DESCRIPTION
This pull request resolves #82 by enabling the following rules in Ruff:
- [pycodestyle](https://docs.astral.sh/ruff/rules/#pycodestyle-e-w).
- [mccabe](https://docs.astral.sh/ruff/rules/#mccabe-c90).
- [pep8-naming](https://docs.astral.sh/ruff/rules/#pep8-naming-n).
- [pyupgrade](https://docs.astral.sh/ruff/rules/#pyupgrade-up).
- [flake8-builtins](https://docs.astral.sh/ruff/rules/#flake8-builtins-a).
- [flake8-comprehensions](https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4).
- [flake8-import-conventions](https://docs.astral.sh/ruff/rules/#flake8-import-conventions-icn).
- [flake8-no-pep420](https://docs.astral.sh/ruff/rules/#flake8-no-pep420-inp).
- [flake8-pie](https://docs.astral.sh/ruff/rules/#flake8-pie-pie).
- [flake8-pytest-style](https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt).
- [flake8-quotes](https://docs.astral.sh/ruff/rules/#flake8-quotes-q).
- [flake8-return](https://docs.astral.sh/ruff/rules/#flake8-return-ret).
- [flake8-simplify](https://docs.astral.sh/ruff/rules/#flake8-simplify-sim).
- [flake8-type-checking](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch).
- [flake8-unused-arguments](https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg).
- [eradicate](https://docs.astral.sh/ruff/rules/#eradicate-era).
- [Pylint](https://docs.astral.sh/ruff/rules/#pylint-pl).
- [Perflint](https://docs.astral.sh/ruff/rules/#perflint-perf).