### PR TITLE
Enable pydocstyle Rules in Ruff

### DIFF
--- a/lib/my_fibonacci/__init__.py
+++ b/lib/my_fibonacci/__init__.py
@@ -1,4 +1,4 @@
-"""Example Module for Python Starter template."""
+"""An example Python module."""
 
 from .sequence import fibonacci_sequence
 

--- a/lib/my_fibonacci/__main__.py
+++ b/lib/my_fibonacci/__main__.py
@@ -1,10 +1,12 @@
+"""An example main Python module."""
+
 import sys
 
 from . import fibonacci_sequence
 
 
 def main():
-    """Main function to print a Fibonacci sequence based on user input."""
+    """Print a Fibonacci sequence based on user input."""
     sequence = fibonacci_sequence(int(sys.argv[1]))
     print(" ".join(str(item) for item in sequence))
 

--- a/lib/my_fibonacci/sequence.py
+++ b/lib/my_fibonacci/sequence.py
@@ -1,4 +1,4 @@
-"""Fibonacci Sequence Generator Module."""
+"""A Fibonacci sequence generator module."""
 
 
 def fibonacci_sequence(n: int) -> list[int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
+extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ omit = ["__main__.py"]
 
 [tool.ruff.lint]
 extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
-ignore = ["D211"]
+ignore = ["D211", "D212"]
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ omit = ["__main__.py"]
 
 [tool.ruff.lint]
 extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
+ignore = ["D211"]
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ omit = ["__main__.py"]
 
 [tool.ruff.lint]
 extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["D"]


### PR DESCRIPTION
This pull request enables all [pydocstyle](https://docs.astral.sh/ruff/rules/#pydocstyle-d) rules in Ruff except for `no-blank-line-before-class` (D211) and `multi-line-summary-first-line` (D212) rules. This pull request also add and audit docstyles in all modules and functions.