### PR TITLE
Enable flake8-annotations Rules in Ruff

### DIFF
--- a/lib/my_fibonacci/__main__.py
+++ b/lib/my_fibonacci/__main__.py
@@ -5,7 +5,7 @@ import sys
 from . import fibonacci_sequence
 
 
-def main():
+def main() -> None:
     """Print a Fibonacci sequence based on user input."""
     sequence = fibonacci_sequence(int(sys.argv[1]))
     print(" ".join(str(item) for item in sequence))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
+extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "ANN", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
 ignore = ["D211", "D212"]
 
 [tool.ruff.per-file-ignores]

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,7 +1,7 @@
 from my_fibonacci import fibonacci_sequence
 
 
-def test_fibonacci_sequence():
+def test_fibonacci_sequence() -> None:
     assert fibonacci_sequence(1) == [1]
     assert fibonacci_sequence(2) == [1, 1]
     assert fibonacci_sequence(5) == [1, 1, 2, 3, 5]


### PR DESCRIPTION
This pull request enables all [flake8-annotations](https://docs.astral.sh/ruff/rules/#flake8-annotations-ann) rules in Ruff. It also fixes missing return type annotations in all functions.