### PR TITLE
Enable flake8-bandit Rules in Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "ANN", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
+extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "ANN", "S", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
 ignore = ["D211", "D212"]
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,4 @@ extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "ANN", "S", "A", "C4", "I
 ignore = ["D211", "D212"]
 
 [tool.ruff.per-file-ignores]
-"tests/*" = ["D"]
+"tests/*" = ["D", "S101"]


### PR DESCRIPTION
This pull request enables all [flake8-bandit](https://docs.astral.sh/ruff/rules/#flake8-bandit-s) rules in Ruff except for `assert` (S101) rule on test files.