### PR TITLE
Enable flake8-bugbear Rules in Ruff

### DIFF
--- a/lib/my_fibonacci/sequence.py
+++ b/lib/my_fibonacci/sequence.py
@@ -4,7 +4,7 @@
 def fibonacci_sequence(n: int) -> list[int]:
     """Generate a Fibonacci sequence up to the given number of terms."""
     sequence = [0, 1]
-    for i in range(n - 1):
+    for _ in range(n - 1):
         sequence.append(sequence[-1] + sequence[-2])
     return sequence[1:]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "ANN", "S", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
+extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "ANN", "S", "B", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
 ignore = ["D211", "D212"]
 
 [tool.ruff.per-file-ignores]


### PR DESCRIPTION
This pull request enables all [flake8-bugbear](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b) rules in Ruff. It also fixes an error regarding to [`unused-loop-control-variable` (B007)](https://docs.astral.sh/ruff/rules/unused-loop-control-variable/) rule.