### PR TITLE
Add Git Attributes for Poetry Lock File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+poetry.lock -diff linguist-generated


### PR DESCRIPTION
This pull request resolves #93 by adding a `.gitattributes` file that sets attributes for the `poetry.lock` file.