### PR TITLE
Fix and Simplify Ruff Linter Rules Configuration

### DIFF
--- a/lib/my_fibonacci/__init__.py
+++ b/lib/my_fibonacci/__init__.py
@@ -1,5 +1,3 @@
-"""An example Python module."""
-
 from .sequence import fibonacci_sequence
 
 __all__ = ["fibonacci_sequence"]

--- a/lib/my_fibonacci/__main__.py
+++ b/lib/my_fibonacci/__main__.py
@@ -1,12 +1,9 @@
-"""An example main Python module."""
-
 import sys
 
 from . import fibonacci_sequence
 
 
 def main() -> None:
-    """Print a Fibonacci sequence based on user input."""
     sequence = fibonacci_sequence(int(sys.argv[1]))
     print(" ".join(str(item) for item in sequence))
 

--- a/lib/my_fibonacci/sequence.py
+++ b/lib/my_fibonacci/sequence.py
@@ -1,6 +1,3 @@
-"""A Fibonacci sequence generator module."""
-
-
 def fibonacci_sequence(n: int) -> list[int]:
     """Generate a Fibonacci sequence up to the given number of terms."""
     if n <= 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,6 @@ omit = ["__main__.py"]
 [tool.ruff.lint]
 select = ["ALL"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__main__.py" = ["T201"]
 "tests/*" = ["D", "S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ fail_under = 100
 omit = ["__main__.py"]
 
 [tool.ruff.lint]
-extend-select = ["E", "W", "C90", "I", "N", "D", "UP", "ANN", "S", "B", "A", "C4", "ICN", "INP", "PIE", "PT", "Q", "RET", "SIM", "TCH", "ARG", "ERA", "PL", "PERF"]
-ignore = ["D211", "D212"]
+select = ["ALL"]
 
 [tool.ruff.per-file-ignores]
+"__main__.py" = ["T201"]
 "tests/*" = ["D", "S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ omit = ["__main__.py"]
 
 [tool.ruff.lint]
 select = ["ALL"]
+ignore = ["D"]
 
 [tool.ruff.lint.per-file-ignores]
 "__main__.py" = ["T201"]
-"tests/*" = ["D", "S101"]
+"tests/*" = ["S101"]


### PR DESCRIPTION
This pull request resolves #289 by fixing and simplifying Ruff linter rules configuration. It enables all rules in the Ruff linter except the pydocstyle rule.