### PR TITLE
Remove Upload Package Step on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,8 +33,3 @@ jobs:
 
       - name: Build Package
         run: poetry build
-
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          path: dist/*


### PR DESCRIPTION
This pull request resolves #291 by removing the "Upload Package" step from the `build` workflow.