### PR TITLE
Fix Conflicting Formatting and Lint Rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ source = ["my_fibonacci"]
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["D"]
+ignore = ["COM812", "D"]
 
 [tool.ruff.lint.per-file-ignores]
 "__main__.py" = ["T201"]


### PR DESCRIPTION
This pull request resolves #299 by ignoring the [missing-trailing-comma (COM812)](https://docs.astral.sh/ruff/rules/missing-trailing-comma) Ruff lint rule.