### PR TITLE
Improve Lefthook Job Glob Configuration

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,4 +23,4 @@ pre-commit:
         - pyproject.toml
 
     - name: check diff
-      run: git diff --exit-code dist {staged_files}
+      run: git diff --exit-code {staged_files}


### PR DESCRIPTION
This pull request resolves #303 by modifying the `glob` option in the `lefthook.yml` file to cover all files that can trigger each job. This change also removed the unused diff check of the `dist` directory.