### PR TITLE
Use argparse for Parsing Arguments

### DIFF
--- a/src/my_fibonacci/__main__.py
+++ b/src/my_fibonacci/__main__.py
@@ -1,10 +1,18 @@
-import sys
+import argparse
 
 from . import fibonacci_sequence
 
 
 def main() -> None:
-    sequence = fibonacci_sequence(int(sys.argv[1]))
+    parser = argparse.ArgumentParser(
+        prog="my_fibonacci",
+        description="Generate a Fibonacci sequence up to the given number of terms.",
+    )
+    parser.add_argument("--version", action="version", version="0.0.0")
+    parser.add_argument("n", type=int, help="The number of terms")
+    args = parser.parse_args()
+
+    sequence = fibonacci_sequence(args.n)
     print(" ".join(str(item) for item in sequence))
 
 


### PR DESCRIPTION
This pull request resolves #307 by utilizing [argparse](https://docs.python.org/3/library/argparse.html) for parsing arguments in the sample `main` function.