### PR TITLE
Remove Glob Pattern for Filtering Lefthook Jobs

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,4 +11,4 @@ pre-commit:
       run: uv run ruff check --fix
 
     - name: check diff
-      run: git diff --exit-code {staged_files}
+      run: git diff --exit-code uv.lock {staged_files}


### PR DESCRIPTION
This pull request resolves #318 by removing the glob pattern used to filter Lefthook jobs. It also adds the `uv.lock` file to the list of files checked for changes.