### PR TITLE
Filter Unnecessary Files from Source Distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ omit = ["__main__.py"]
 [tool.coverage.run]
 source = ["bonacci"]
 
+[tool.hatch.build.targets.sdist]
+include = ["src"]
+
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = ["COM812", "D"]


### PR DESCRIPTION
This pull request resolves #321 by configuring the template to include only the `src` directory in the source distribution.
