### PR TITLE
Replace Print Function with Standard Output Write in CLI Program

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,4 @@ select = ["ALL"]
 ignore = ["COM812", "D"]
 
 [tool.ruff.lint.per-file-ignores]
-"__main__.py" = ["T201"]
 "tests/*" = ["S101"]

--- a/src/bonacci/__main__.py
+++ b/src/bonacci/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from . import fibonacci_sequence
 
@@ -13,7 +14,7 @@ def main() -> None:
     args = parser.parse_args()
 
     sequence = fibonacci_sequence(args.n)
-    print(" ".join(str(item) for item in sequence))
+    sys.stdout.write(f"{' '.join(str(item) for item in sequence)}\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request resolves #323 by replacing the `print` function in the `__main__.py` file with `sys.stdout.write`.