### PR TITLE
Add Docstring API Documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ include = ["src"]
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["COM812", "D"]
+ignore = ["COM812", "D203", "D213"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101"]
+"tests/*" = ["S101", "D"]

--- a/src/bonacci/__init__.py
+++ b/src/bonacci/__init__.py
@@ -1,3 +1,5 @@
+"""Example Python package for generating Fibonacci sequences."""
+
 from .sequence import fibonacci_sequence
 
 __all__ = ["fibonacci_sequence"]

--- a/src/bonacci/__main__.py
+++ b/src/bonacci/__main__.py
@@ -1,3 +1,5 @@
+"""Example main module for the CLI application."""
+
 import argparse
 import sys
 
@@ -5,6 +7,7 @@ from . import fibonacci_sequence
 
 
 def main() -> None:
+    """Generate and print a Fibonacci sequence based on command line arguments."""
     parser = argparse.ArgumentParser(
         prog="bonacci",
         description="Generate a Fibonacci sequence up to the given number of terms",

--- a/src/bonacci/sequence.py
+++ b/src/bonacci/sequence.py
@@ -1,3 +1,6 @@
+"""Example functions for generating Fibonacci sequences."""
+
+
 def fibonacci_sequence(n: int) -> list[int]:
     """Generate a Fibonacci sequence up to the given number of terms."""
     if n <= 0:


### PR DESCRIPTION
This pull request resolves #325 by adding example docstring API documentation to the project. This change also enables the pydocstyle (`D`) lint rule.
