### PR TITLE
Use dprint to Format Source Code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Install Dependencies
         run: uv sync --locked
 
-      - name: Check Format
-        run: uv run ruff format --diff
+      - name: Check Formatting
+        uses: dprint/check@v2.3
 
       - name: Check Lint
         run: uv run ruff check

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This template provides a basic Python project containing an example package with
 
 ## Key Features
 
-* Uses [uv](https://docs.astral.sh/uv/) as the package manager.
-* Supports formatting and linting with [Ruff](https://github.com/astral-sh/ruff), and testing with [Pytest](https://docs.pytest.org/en/stable/).
-* Fixes formatting and linting during pre-commit hooks using [Lefthook](https://lefthook.dev/).
-* Preconfigured workflows for [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions).
+- Uses [uv](https://docs.astral.sh/uv/) as the package manager.
+- Supports formatting and linting with [dprint](https://dprint.dev/) and [Ruff](https://github.com/astral-sh/ruff).
+- Supports testing and coverage checks with [Pytest](https://docs.pytest.org/en/stable/).
+- Fixes formatting and linting issues during pre-commit hooks using [Lefthook](https://lefthook.dev/).
+- Includes preconfigured workflows for [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions).
 
 ## Usage
 

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.20.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.19.0.wasm",
+    "https://plugins.dprint.dev/toml-0.7.0.wasm",
+    "https://plugins.dprint.dev/ruff-0.4.1.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm"
+  ]
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,7 +5,7 @@ pre-commit:
       run: uv sync
 
     - name: fix formatting
-      run: uv run ruff format
+      run: dprint fmt
 
     - name: fix lint
       run: uv run ruff check --fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,15 @@ version = "0.0.0"
 dependencies = []
 requires-python = ">=3.13"
 authors = [
-    {name = "Leonardo Bonacci", email = "leonardo@bonacci.com"},
+  { name = "Leonardo Bonacci", email = "leonardo@bonacci.com" },
 ]
 description = "An example Python project for generating a Fibonacci sequence"
 readme = "README.md"
 license = "Unlicense"
 keywords = ["example", "fibonacci"]
 classifiers = [
-    "Development Status :: 1 - Planning",
-    "Programming Language :: Python :: 3 :: Only",
+  "Development Status :: 1 - Planning",
+  "Programming Language :: Python :: 3 :: Only",
 ]
 
 [project.scripts]
@@ -28,10 +28,10 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "lefthook>=1.11.14",
-    "pytest>=8.4.0",
-    "pytest-cov>=6.2.1",
-    "ruff>=0.11.13",
+  "lefthook>=1.11.14",
+  "pytest>=8.4.0",
+  "pytest-cov>=6.2.1",
+  "ruff>=0.11.13",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
This pull request resolves #326 by utilizing dprint to format the source code in this project, expanding the formatting to cover all configuration files in addition to the Python source files.
