### PR TITLE
Synchronize Dependency Versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-  "lefthook>=1.11.14",
-  "pytest>=8.4.0",
+  "lefthook>=1.12.4",
+  "pytest>=8.4.2",
   "pytest-cov>=7.0.0",
-  "ruff>=0.11.13",
+  "ruff>=0.12.8",
 ]
 
 [tool.coverage.report]

--- a/uv.lock
+++ b/uv.lock
@@ -19,10 +19,10 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "lefthook", specifier = ">=1.11.14" },
-    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "lefthook", specifier = ">=1.12.4" },
+    { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "ruff", specifier = ">=0.11.13" },
+    { name = "ruff", specifier = ">=0.12.8" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request resolves #352 by synchronizing the dependency versions in the `pyproject.toml` and `uv.lock` files.